### PR TITLE
Update 021-rhnServerNetwork-trigger.sql.oracle

### DIFF
--- a/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/021-rhnServerNetwork-trigger.sql.oracle
+++ b/schema/spacewalk/upgrade/spacewalk-schema-2.2-to-spacewalk-schema-2.3/021-rhnServerNetwork-trigger.sql.oracle
@@ -13,7 +13,16 @@
 -- in this software or its documentation. 
 --
 
-drop trigger if exists rhn_servnet_ipaddr_mon_trig;
+declare
+        e exception;
+        pragma exception_init(e,-4080);
+begin
+        execute immediate 'drop trigger rhn_servnet_ipaddr_mon_trig';
+exception
+        when e then
+                null;
+end;
+/
 
 create or replace trigger
 rhn_servernetwork_mod_trig


### PR DESCRIPTION
IF EXISTS does not exist on oracle. This fails the upgrade from 2.2 to 2.3. Removing IF EXISTS part does work and lets upgrade run smoothly. ... this request now really checks if the trigger already exists ... so this request supersedes https://github.com/spacewalkproject/spacewalk/pull/250
